### PR TITLE
Remove reattach-to-user-namespace

### DIFF
--- a/tmux-osx.conf
+++ b/tmux-osx.conf
@@ -1,3 +1,0 @@
-# Accessing the macOS pasteboard in tmux sessions
-# https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
-set-option -g default-command "reattach-to-user-namespace -l zsh"

--- a/tmux.conf
+++ b/tmux.conf
@@ -44,7 +44,5 @@ bind-key a send-prefix
 bind-key & kill-window
 bind-key x kill-pane
 
-if-shell 'test "$(uname)" = "Darwin"' 'source ~/.tmux-osx.conf'
-
 # Load local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'


### PR DESCRIPTION
Since Tmux 2.6 this is included, so we don't need to do that manually.

Note in Changelog:
https://github.com/tmux/tmux/blob/8aaf86a6ead9852631342d0d2d526a7eaede15cf/CHANGES#L66

Initial issue:
https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/issues/66

Fixes #23