### PR TITLE
Move tmux windows with "alt+a <" and "alt+a >"

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -44,5 +44,9 @@ bind-key a send-prefix
 bind-key & kill-window
 bind-key x kill-pane
 
+# Move windows left and right
+bind-key < swap-window -t -1
+bind-key > swap-window -t +1
+
 # Load local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'

--- a/tmux.conf
+++ b/tmux.conf
@@ -45,8 +45,8 @@ bind-key & kill-window
 bind-key x kill-pane
 
 # Move windows left and right
-bind-key < swap-window -t -1
-bind-key > swap-window -t +1
+bind-key H swap-window -t -1
+bind-key L swap-window -t +1
 
 # Load local config
 if-shell "[ -f ~/.tmux.conf.local ]" 'source ~/.tmux.conf.local'


### PR DESCRIPTION
Sometimes you need to rearrange tmux windows. Now it is easy with `<` and `>`.