### PR TITLE
changed alias command

### DIFF
--- a/aliases
+++ b/aliases
@@ -20,8 +20,12 @@ alias gbr="git branch"
 
 alias gp="git push"
 alias gpo="git push origin"
-alias gpom="git push origin master"
-alias gphm="git push heroku master"
+alias gpoh="git push origin HEAD"
+alias gphh="git push heroku HEAD"
+
+# Keep old aliases
+alias gpom="gpoh"
+alias gphm="gphh"
 
 alias gf="git fetch"
 alias gpr="git pr"

--- a/aliases
+++ b/aliases
@@ -24,8 +24,8 @@ alias gpoh="git push origin HEAD"
 alias gphh="git push heroku HEAD"
 
 # Keep old aliases
-alias gpom="gpoh"
-alias gphm="gphh"
+alias gpom="git push origin master"
+alias gphm="git push heroku master"
 
 alias gf="git fetch"
 alias gpr="git pr"


### PR DESCRIPTION
git push origin HEAD will push the current branch, that's why I'm not sure whether it would still work as intended.

I've also changed gpom and gphm to gpoh and gphh, and made old aliases available.