### PR TITLE
added user and host to prompt when in a ssh session

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -19,3 +19,7 @@ GIT_PROMPT_DIRTY="%{$fg_bold[yellow]%}*%{$reset_color%}"
 
 setopt PROMPT_SUBST
 PS1='%{$fg[green]%}%3~$(git_prompt_info) %{$reset_color%}$ '
+
+if (( ${+SSH_CLIENT} )) || (( ${+SSH_TTY} )) || (( ${+SSH_CONNECTION} )); then 
+  PS1="$USER@%M%{$reset_color%}:$PS1"
+fi

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -20,6 +20,6 @@ GIT_PROMPT_DIRTY="%{$fg_bold[yellow]%}*%{$reset_color%}"
 setopt PROMPT_SUBST
 PS1='%{$fg[green]%}%3~$(git_prompt_info) %{$reset_color%}$ '
 
-if [[ -v SSH_CLIENT]] || [[ -v SSH_TTY ]] || [[ -v SSH_CONNECTION ]]; then 
+if [[ -v SSH_CLIENT ]] || [[ -v SSH_TTY ]] || [[ -v SSH_CONNECTION ]]; then 
   PS1="$USER@%M%{$reset_color%}:$PS1"
 fi

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -20,6 +20,6 @@ GIT_PROMPT_DIRTY="%{$fg_bold[yellow]%}*%{$reset_color%}"
 setopt PROMPT_SUBST
 PS1='%{$fg[green]%}%3~$(git_prompt_info) %{$reset_color%}$ '
 
-if (( ${+SSH_CLIENT} )) || (( ${+SSH_TTY} )) || (( ${+SSH_CONNECTION} )); then 
+if [[ -v SSH_CLIENT]] || [[ -v SSH_TTY ]] || [[ -v SSH_CONNECTION ]]; then 
   PS1="$USER@%M%{$reset_color%}:$PS1"
 fi


### PR DESCRIPTION
Code checks for the presence of SSH specific env variables. In case they are, appends ```user@hostname``` before the rest of the prompt.
Not sure whether it is needed to show the user but I still added.